### PR TITLE
chore: update typing for GenericSecretProvider.getSecrets

### DIFF
--- a/src/providers/GenericProvider.ts
+++ b/src/providers/GenericProvider.ts
@@ -1,7 +1,7 @@
 import { SecretProvider } from '../SecretProvider';
 
 export class GenericSecretProvider extends SecretProvider<null> {
-  constructor(private getSecrets: () => Promise<Record<string, string>>) {
+  constructor(private getSecrets: () => Promise<Record<string, string>> | Record<string, string>) {
     super();
   }
 


### PR DESCRIPTION
The usage of `Promise.resolve` looks like the intent was for `getSecrets` to also support sync getters.