### PR TITLE
feat: add support for more than just circleci as a provider

### DIFF
--- a/src/oidc/handlers.ts
+++ b/src/oidc/handlers.ts
@@ -1,0 +1,102 @@
+import { FastifyBaseLogger } from 'fastify';
+import {
+  CircleOIDCPlatform,
+  InvalidOIDCPlatform,
+  OIDCSecretExchangeConfig,
+  OIDCSecretExchangeConfigItem,
+  OIDCSecretExchangeConfiguration,
+} from '../config';
+import { BaseClaims, CircleCIOIDCClaims } from '../type';
+import { getValidatedToken } from './validate-token';
+
+export type SubjectedSecretProvider = {
+  subject: string;
+  providers: OIDCSecretExchangeConfiguration<object, unknown>['provider'][];
+};
+
+export type PlatformHandler<
+  TConfig extends OIDCSecretExchangeConfig[0],
+  TClaims extends BaseClaims,
+> = {
+  discoveryUrlForToken: (config: TConfig, token: string) => string | null;
+  validateToken: (token: string, discoveryUrl: string) => Promise<TClaims | null>;
+  filterSecretProviders: (config: TConfig, claims: TClaims) => Promise<SubjectedSecretProvider>;
+};
+
+const circleci: PlatformHandler<
+  OIDCSecretExchangeConfigItem<CircleOIDCPlatform>,
+  CircleCIOIDCClaims
+> = {
+  discoveryUrlForToken: (config, token) => {
+    // TODO: Pre-validate the token to claim this audience
+    return `https://oidc.circleci.com/org/${config.organizationId}`;
+  },
+  validateToken: async (token, discoveryUrl) => {
+    return await getValidatedToken(token, discoveryUrl);
+  },
+  filterSecretProviders: async (config, claims) => {
+    // Do a quick-pass to filter down secret providers based on contextId and projectId claims
+    const projectId = claims['oidc.circleci.com/project-id'];
+    // It is currently specified by CircleCI that this token will only ever have a single context ID
+    // Ref: https://circleci.com/docs/openid-connect-tokens/#format-of-the-openid-connect-id-token
+    // Due to a bug however the OIDC token may claim a "null" context-ids array, in that case
+    // we assume 0 contexts to take the least-privilege approach
+    let validatedContextIds = claims['oidc.circleci.com/context-ids'];
+    if (validatedContextIds === null) {
+      validatedContextIds = [];
+    }
+    const contextId = validatedContextIds[0];
+    const filteredSecretProviders = config.secrets
+      .filter((provider) => {
+        if (!provider.filters.projectIds.includes(projectId)) return false;
+        // If the wildcard context is allowed then we don't need to check the contextIds filter
+        if (!provider.filters.contextIds.includes('*')) {
+          // If the contextId is missing from the claim don't validate it in case consumers
+          // accidentally put `undefined` in the contextIds array
+          if (!contextId || !provider.filters.contextIds.includes(contextId)) return false;
+        }
+        return true;
+      })
+      .map((p) => p.provider);
+
+    return { subject: claims.sub, providers: filteredSecretProviders };
+  },
+};
+
+const invalid: PlatformHandler<OIDCSecretExchangeConfigItem<InvalidOIDCPlatform>, BaseClaims> = {
+  discoveryUrlForToken: () => {
+    return null;
+  },
+  validateToken: async () => {
+    return null;
+  },
+  filterSecretProviders: async (_, claims) => {
+    return { subject: claims.sub, providers: [] };
+  },
+};
+
+export const perPlatformHandlers = {
+  circleci,
+  invalid,
+};
+
+export const getProvidersForConfig = async <
+  TClaims extends BaseClaims,
+  TConfig extends OIDCSecretExchangeConfig[0],
+  THandler extends PlatformHandler<TConfig, TClaims>,
+>(
+  logger: FastifyBaseLogger,
+  config: TConfig,
+  handler: THandler & PlatformHandler<TConfig, TClaims>,
+  token: string,
+) => {
+  const discoveryUrl = handler.discoveryUrlForToken(config, token);
+  if (!discoveryUrl) return null;
+
+  const claims = await handler.validateToken(token, discoveryUrl);
+  if (!claims) return null;
+
+  logger.info(`Validated incoming OIDC token from: ${claims.sub}`);
+
+  return await handler.filterSecretProviders(config, claims);
+};

--- a/src/oidc/validate-token.ts
+++ b/src/oidc/validate-token.ts
@@ -2,10 +2,12 @@ import got from 'got';
 import { BaseClient, Issuer } from 'openid-client';
 import * as jwkToPem from 'jwk-to-pem';
 import * as jwt from 'jsonwebtoken';
-import { CircleCIOIDCClaims } from '../type';
 import * as path from 'path';
 
-export async function getValidatedToken(token: string, discoveryUrl: string) {
+export async function getValidatedToken<TClaims extends object>(
+  token: string,
+  discoveryUrl: string,
+): Promise<TClaims | null> {
   if (!token) {
     // Token is an empty string, no point even trying
     return null;
@@ -71,5 +73,5 @@ export async function getValidatedToken(token: string, discoveryUrl: string) {
     return null;
   }
 
-  return verifiedClaims.payload as CircleCIOIDCClaims;
+  return verifiedClaims.payload as TClaims;
 }

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,3 +1,7 @@
+export type BaseClaims = {
+  sub: string;
+};
+
 export type CircleCIOIDCClaims = {
   /**
    * The subject. This identifies who is running the CircleCI job and where. Its value is "org/ORGANIZATION_ID/project/PROJECT_ID/user/USER_ID", a string, where ORGANIZATION_ID, PROJECT_ID, and USER_ID are UUIDs that identify the CircleCI organization, project, and user, respectively. The user is the CircleCI user that caused this job to run.


### PR DESCRIPTION
BREAKING CHANGE: This is a change in configuration types

This module still just supports `circleci` after this change, but this lays the group work for future services to be supported in semver/minor bumps in a relatively lightweight way.

To prove this works / supports "multiple" this PR does land an `invalid` config type which maps to 0 secrets every time, but demonstrates how one would add another service to this exchange tool