### PR TITLE
ci: use electronjs/node orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,29 +1,20 @@
 version: 2.1
+
 orbs:
   cfa: continuousauth/npm@2.1.0
-jobs:
-  test:
-    docker:
-      - image: cimg/node:16.19
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
-            - v1-dependencies-{{ arch }}
-      - run: yarn --frozen-lockfile
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
-      - run: yarn build
-      - run: yarn test
+  node: electronjs/node@2.2.2
 
 workflows:
-  version: 2
   test_and_release:
     jobs:
-      - test
+      - node/test:
+          executor: node/linux
+          name: test
+          node-version: "18.20"
+          test-steps:
+            - run: yarn build
+            - run: yarn test
+          use-test-steps: true
       - cfa/release:
           requires:
             - test


### PR DESCRIPTION
Simplifies the config and bumps Node.js off of an EOL version.