### PR TITLE
chore: add `engines.node` to package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "dist/index.js",
   "author": "Samuel Attard",
   "license": "MIT",
+  "engines": {
+    "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+  },
   "scripts": {
     "build": "tsc",
     "eslint": "eslint --ext .ts src test",


### PR DESCRIPTION
This is based on Jest since we need tests to pass:

https://github.com/jestjs/jest/blob/05deb8393c4ad71e19be2567b704dfd3a2ab5fc9/package.json#L171-L173