### PR TITLE
build: add URL fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
   "main": "dist/index.js",
   "author": "Samuel Attard",
   "license": "MIT",
+  "homepage": "https://github.com/electron/circleci-oidc-secret-exchange",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electron/circleci-oidc-secret-exchange.git"
+  },
+  "bugs": {
+    "url": "https://github.com/electron/circleci-oidc-secret-exchange/issues"
+  },
   "engines": {
     "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
   },


### PR DESCRIPTION
Provides a nicer experience for the package page on npm.